### PR TITLE
DELUSER command

### DIFF
--- a/SRCLIB/deluser.hlasm
+++ b/SRCLIB/deluser.hlasm
@@ -1,0 +1,479 @@
+DELUSER  TITLE 'Deleta RAKF users from the control data sets'           00000100
+*---------------------------------------------------------------------* 00000200
+*                                                                     * 00000300
+*        Module:       DELUSER                                        * 00000400
+*                                                                     * 00000500
+*        Author:       Rob Prins                                      * 00000600
+*                                                                     * 00000700
+*        Attributes:   RENT, REUS.                                    * 00000800
+*                                                                     * 00000900
+*        Function:     Parse the syntax of the DELUSER command.       * 00001000
+*                      Allocate SYS1.SECURE.CNTL(USERS) and           * 00001100
+*                      SYS1.SECURE.SHADOW dynamically with IKJDAIR.   * 00001200
+*                      Read the USERS table into storage,             * 00001300
+*                      delete the user and write the table back.      * 00001400
+*                      Read the SHADOW data set into storage,         * 00001500
+*                      delete the user and write the table back into  * 00001600
+*                      the SHADOW data set.                           * 00001700
+*                      Free the SYS1.SECURE.* data sets.              * 00001800
+*                                                                     * 00001900
+*        Syntax:       DELUSER userid                                 * 00002000
+*                                                                     * 00002100
+*        Return codes: 00 - all good.                                 * 00002200
+*                      08 - an error occurred, user is notified       * 00002300
+*                           with a message                            * 00002400
+*                                                                     * 00002500
+*---------------------------------------------------------------------* 00002600
+DELUSER  CSECT                                                          00002700
+         SAVE  (14,12)                                                  00002800
+         LR    R12,R15                                                  00002900
+         USING DELUSER,R12             Base register                    00003000
+         LR    R2,R1                   Save parm (CPPL)                 00003100
+         GETMAIN RU,LV=WORKL           Obtain savearea + working strg.  00003200
+         ST    R1,8(,R13)              Forward pointer                  00003300
+         ST    R13,4(,R1)              Backward pointer                 00003400
+         LR    R13,R1                  This is our save area            00003500
+         USING WORKAREA,R13            Base working storage             00003600
+         ST    R2,MYCPPL               Save our CPPL address            00003700
+START    DS    0H                                                       00003800
+         MVC   RAKFSHAD,MDLSHAD        Move ...                         00003900
+         MVC   RAKFUSER,MDLUSER             ... model DCBs              00004000
+         XC    DAIR08,DAIR08           Clear IKJDAIR                    00004100
+         XC    DAIR18,DAIR18                        ... blocks          00004200
+         XC    ANSWER,ANSWER           Clear IKJPARS answer             00004300
+         MVC   MSG3,MSG3X              Move message to working storage  00004400
+         MVC   MSG6,MSG6X              Move message to working storage  00004500
+         MVI   SW,0                    Clear flags                      00004600
+         LA    R0,DCBABEND             DCB abend exit                   00004700
+         ST    R0,EXLST                Save JFCB in exit list           00004800
+         MVI   EXLST,X'91'             DCB abend exit is last entry     00004900
+         LA    R0,EXLST                Exit list (DCB abend exit)       00005000
+         STCM  R0,B'0111',RAKFUSER+DCBEXLSA-IHADCB                      00005100
+         STCM  R0,B'0111',RAKFSHAD+DCBEXLSA-IHADCB                      00005200
+         GETMAIN RU,LV=104000      GETMAIN room for 1300 user records   00005300
+         ST    R1,ADRUSER              Save its address                 00005400
+*---------------------------------------------------------------------* 00005500
+*        Parse parameters                                             * 00005600
+*---------------------------------------------------------------------* 00005700
+         GETMAIN RU,LV=PPL#L           Obtain a dynamic PPL workarea    00005800
+         STM   R0,R1,PPL#LA            Save length and address of PPL   00005900
+         L     R2,PPL#PTR              Get the address of the PPL       00006000
+         USING PPL,R2                  Adress it                        00006100
+         L     R1,MYCPPL               Get address of CPPL              00006200
+         USING CPPL,R1                 Address it                       00006300
+*---------------------------------------------------------------------* 00006400
+*        Populate the Parse Parameter List (PPL) from the CPPL,         00006500
+*        add the IKJPARMD list in the PPL and invoke IKJPARS            00006600
+*---------------------------------------------------------------------* 00006700
+*                                                                       00006800
+         MVC   PPLUPT,CPPLUPT          Put in the UPT address from CPPL 00006900
+         MVC   PPLECT,CPPLECT          Put in the ECT address from CPPL 00007000
+         MVC   PPLCBUF,CPPLCBUF        Put in the command buffer addr.  00007100
+*                                      From the CPPL                    00007200
+         XC    ECB,ECB                 Clear Event control block        00007300
+         L     R1,=A(ADDPCL)           Address of PCL                   00007400
+         ST    R1,PPLPCL               Set in PPL                       00007500
+         LA    R1,ANSWER               Answer area                      00007600
+         ST    R1,PPLANS               Pointer into PPL                 00007700
+         LA    R1,ECB                  Event control block              00007800
+         ST    R1,PPLECB               Pointer into PPL                 00007900
+         ST    R13,PPLUWA              User provide workarea            00008000
+         CALLTSSR EP=IKJPARS,MF=(E,PPL)   Invoke parse                  00008100
+         DROP  R1,R2                   CPPL and PPL                     00008200
+         LTR   R15,R15                 Parse successfully processed?    00008300
+         BZ    PARSEOK                 Yes: carry                       00008400
+         LA    R0,L'MSG5               Length                           00008500
+         LA    R1,MSG5                 Message                          00008600
+         BAL   R14,TPUT                                                 00008700
+         B     RC08                    Return to TMP                    00008800
+PARSEOK  DS    0H                                                       00008900
+         L     R8,ANSWER               Pointer to PDL                   00009000
+         USING ADDPRS,R8               mapped with IKJPARM              00009100
+         MVC   USERID,=CL8' '          Initialize UserID                00009200
+         LA    R3,UIDPDE               UserID PDE                       00009300
+         USING UIDRET,R3               Base this PDE                    00009400
+         L     R1,UIDPTR               Pointer to UserID                00009500
+         LH    R2,UIDL                 Length                           00009600
+         BCTR  R2,0                    -1 for EX                        00009700
+         EX    R2,MVEUID               Move UserID                      00009800
+         B     ENDPARS                 Branch over EX                   00009900
+MVEUID   MVC   USERID(0),0(R1)         << Executed >>                   00010000
+         DROP  R3                      Unbase UIDRET                    00010100
+ENDPARS  DS    0H                                                       00010200
+*---------------------------------------------------------------------* 00010300
+*        Allocate SYS1.SECURE.CNTL(USERS) and SYS1.SECURE.SHADOW      * 00010400
+*---------------------------------------------------------------------* 00010500
+         LA    R3,DAIR08               Allocation request block         00010600
+         USING DAPB08,R3               Base DAPB08                      00010700
+         MVI   DA08CD+1,X'08'          Entry code 08 (allocation)       00010800
+         MVC   DA08DDN,=CL8'RAKFUSER'  DDNAME to allocate               00010900
+         MVC   DA08PDSN,=A(USRDSNL)    Temporary data set name          00011000
+         MVI   DA08DSP1,DA08SHR        DISP=SHR                         00011100
+         MVC   DA08MNM,=CL8'USERS'     Fixed member name                00011200
+         MVI   DA08UNIT,C' '           Clear unit name                  00011300
+         MVC   DA08UNIT+1(L'DA08UNIT-1),DA08UNIT                        00011400
+         MVI   DA08SER,C' '            Clear volume serial              00011500
+         MVC   DA08SER+1(L'DA08SER-1),DA08UNIT                          00011600
+         LR    R1,R3                   Parameter CALLTS                 00011700
+         BAL   R14,CALLTS              IKJDAIR routine                  00011800
+         LTR   R15,R15                 Allocation OK?                   00011900
+         BZ    DELU001                 Yes: carry on                    00012000
+         LA    R1,MSG1                 Msg: 'allocation error USER'     00012100
+         LA    R0,L'MSG1               Length                           00012200
+         BAL   R14,TPUT                Write the message on screen      00012300
+         B     RC08                    Return code 8                    00012400
+DELU001  DS    0H                                                       00012500
+         MVC   DA08DDN,=CL8'RAKFSHAD'  DDNAME to allocate               00012600
+         MVC   DA08PDSN,=A(SHDDSNL)    Temporary data set name          00012700
+         MVI   DA08MNM,C' '            Clear member name                00012800
+         MVC   DA08MNM(L'DA08MNM-1),DA08MNM                             00012900
+         LR    R1,R3                   Parameter CALLTS                 00013000
+         BAL   R14,CALLTS              IKJDAIR routine                  00013100
+         LTR   R15,R15                 Allocation OK?                   00013200
+         BZ    DELU003                 Yes: carry on                    00013300
+         LA    R1,MSG2                 Msg: 'allocation error SHADOW'   00013400
+         LA    R0,L'MSG2               Length                           00013500
+         BAL   R14,TPUT                Write the message on screen      00013600
+         BAL   R14,FREE                Free the data sets               00013700
+         B     RC08                    Return code 8                    00013800
+         DROP  R3                      Unbase DABP08                    00013900
+DELU003  DS    0H                                                       00014000
+*---------------------------------------------------------------------* 00014100
+*        Open SYS1.SECURE.CNTL(USERS) with DDNAME RAKUSER             * 00014200
+*---------------------------------------------------------------------* 00014300
+         MVI   OPEND,X'80'             First and only DCB               00014400
+         OPEN  RAKFUSER,MF=(E,OPEND)                                    00014500
+         TM    SW,$913                 Access denied?                   00014600
+         BNO   DELU005                 No: assumed, that open is succes 00014700
+         MVC   MSG3+9(8),=CL8'RAKFUSER'  DD-name                        00014800
+         LA    R1,MSG3                 Msg: 'xxxxxxxx access denied'    00014900
+         LA    R0,L'MSG3               Length                           00015000
+         BAL   R14,TPUT                Write the message on screen      00015100
+         BAL   R14,FREE                Free the data sets               00015200
+         B     RC08                    Return code 8                    00015300
+DELU005  DS    0H                                                       00015400
+*---------------------------------------------------------------------* 00015500
+*        Open SYS1.SECURE.SHADOW with DDNAME RAKFSHAD                 * 00015600
+*---------------------------------------------------------------------* 00015700
+         MVI   OPEND,X'80'             First and only DCB               00015800
+         OPEN  RAKFSHAD,MF=(E,OPEND)                                    00015900
+         TM    SW,$913                 Access denied?                   00016000
+         BNO   DELU007                 No: assumed, that open is succes 00016100
+         MVC   MSG3+9(8),=CL8'RAKFSHAD'  DD-name                        00016200
+         LA    R1,MSG3                 Msg: 'xxxxxxxx access denied'    00016300
+         LA    R0,L'MSG3               Length                           00016400
+         BAL   R14,TPUT                Write the message on screen      00016500
+         BAL   R14,CLOSE                                                00016600
+         BAL   R14,FREE                Free the data sets               00016700
+         B     RC08                    Return code 8                    00016800
+DELU007  DS    0H                                                       00016900
+*---------------------------------------------------------------------* 00017000
+*        Read the USERS records and check if UserID is present        * 00017100
+*        And populate the table with User records except the to       * 00017200
+*        be deleted user.                                             * 00017300
+*---------------------------------------------------------------------* 00017400
+         XR    R5,R5                   Clear record counter             00017500
+         L     R6,ADRUSER              Start of user table              00017600
+DELU009  DS    0H                                                       00017700
+         GET   RAKFUSER,USERREC        Read a record                    00017800
+         CLC   USERUID,USERID          Match found of UserID?           00017900
+         BE    DELU010                 Yes: place not in table          00018000
+         MVC   0(80,R6),USERREC        Record into table                00018100
+         LA    R6,80(,R6)              Next entry in table              00018200
+         LA    R5,1(,R5)               Count record                     00018300
+         C     R5,=F'1300'             Already 1300 records in table?   00018400
+         BL    DELU009                 No: room enough                  00018500
+         LA    R1,MSG7                 Msg: 'table full'                00018600
+         LA    R0,L'MSG7               Length                           00018700
+         BAL   R14,TPUT                Write the message on screen      00018800
+         BAL   R14,CLOSE               Close RAKFUSER and RAKFSHAD      00018900
+         BAL   R14,FREE                Free the data sets               00019000
+         B     RC08                    Return code 8                    00019100
+DELU010  OI    SW,$DEL                 Mark User deleted                00019200
+         B     DELU009                 Read next record                 00019300
+USEREOF  DS    0H                      EOF RACFUSER                     00019400
+         L     R6,ADRUSER              Point to start of table          00019500
+         MVI   CLOSED,X'80'            First and only DCB               00019600
+         CLOSE RAKFUSER,MF=(E,CLOSED)                                   00019700
+         MVI   OPEND,X'80'             First and only DCB               00019800
+         OPEN  (RAKFUSER,(OUTPUT)),MF=(E,OPEND)                         00019900
+         TM    SW,$913                 Access denied?                   00020000
+         BNO   DELU012                 No: assumed, that open is succes 00020100
+         MVC   MSG3+9(8),=CL8'RAKFUSER'  DD-name                        00020200
+         LA    R1,MSG3                 Msg: 'xxxxxxxx access denied'    00020300
+         LA    R0,L'MSG3               Length                           00020400
+         BAL   R14,TPUT                Write the message on screen      00020500
+         BAL   R14,CLOSE               Close RAKFUSER and RAKFSHAD      00020600
+         BAL   R14,FREE                Free the data sets               00020700
+         B     RC08                    Return code 8                    00020800
+DELU012  PUT   RAKFUSER,0(R6)          Write record back in USERS       00020900
+         LA    R6,80(,R6)              Next user entry in table         00021000
+         BCT   R5,DELU012              And write all entries back       00021100
+DELU013  DS    0H                                                       00021200
+         XR    R5,R5                   Re-init record counter           00021300
+         L     R6,ADRUSER              Use same table for SHADOW        00021400
+*---------------------------------------------------------------------* 00021500
+*        Read the SHADOW record and place the user, except the to     * 00021600
+*        be deleted user in the storage table.                        * 00021700
+*---------------------------------------------------------------------* 00021800
+DELU015  DS    0H                                                       00021900
+         GET   RAKFSHAD,SHADOW         Read a shadow record             00022000
+         CLC   SHDUID(8),USERID        Match found of UserID?           00022100
+         BE    DELU016                 No: read next record             00022200
+         MVC   0(48,R6),SHADOW         Record into table                00022300
+         LA    R5,1(,R5)               Count record in table            00022400
+         LA    R6,48(,R6)              Next entry in table              00022500
+         B     DELU015                 Read next record                 00022600
+DELU016  OI    SW,$DEL                 Mark User deleted                00022700
+         B     DELU015                 Read next record                 00022800
+SHADEOF  DS    0H                      EOF RACFSHAD                     00022900
+         L     R6,ADRUSER              Start of user table              00023000
+         MVI   CLOSED,X'80'            First and only DCB               00023100
+         CLOSE RAKFSHAD,MF=(E,CLOSED)                                   00023200
+         MVI   OPEND,X'80'             First and only DCB               00023300
+         OPEN  (RAKFSHAD,(OUTPUT)),MF=(E,OPEND)                         00023400
+         TM    SW,$913                 Access denied?                   00023500
+         BNO   DELU018                 No: assumed, that open is succes 00023600
+         MVC   MSG3+9(8),=CL8'RAKFSHAD'  DD-name                        00023700
+         LA    R1,MSG3                 Msg: 'xxxxxxxx access denied'    00023800
+         LA    R0,L'MSG3               Length                           00023900
+         BAL   R14,TPUT                Write the message on screen      00024000
+         BAL   R14,CLOSE               Close RAKFUSER and RAKFSHAD      00024100
+         BAL   R14,FREE                Free the data sets               00024200
+         B     RC08                    Return code 8                    00024300
+DELU018  PUT   RAKFSHAD,0(R6)          Write record back in SHADOW      00024400
+         LA    R6,48(,R6)              Next SHADOW entry in table       00024500
+         BCT   R5,DELU018              And write all entries back       00024600
+*---------------------------------------------------------------------* 00024700
+*        Close USERS and SHADOW and return to TMP.                    * 00024800
+*---------------------------------------------------------------------* 00024900
+DELU021  DS    0H                                                       00025000
+         BAL   R14,CLOSE               Close the data sets              00025100
+         BAL   R14,FREE                And unallocate                   00025200
+         LA    R15,0                   RC = 0                           00025300
+         B     RETURN                                                   00025400
+*---------------------------------------------------------------------* 00025500
+*        Return to TSO TMP.                                           * 00025600
+*---------------------------------------------------------------------* 00025700
+RC08     DS    0H                                                       00025800
+         LA    R15,8                   RC = 8                           00025900
+RETURN   DS    0H                                                       00026000
+         LR    R4,R15                  Save return code                 00026100
+         LM    R2,R3,PPL#LA            Address + Length PPL             00026200
+         FREEMAIN RU,LV=(2),A=(3)      Free the PPL                     00026300
+         L     R2,ADRUSER              Address of user table            00026400
+         FREEMAIN RU,LV=104000,A=(2)                                    00026500
+         TM    SW,$DEL                 Anything deleted?                00026600
+         BNZ   RETURN2                 Yes: carry on                    00026700
+         LA    R1,MSG4                 Msg: 'nothing deleted'           00026800
+         LA    R0,L'MSG4               Length                           00026900
+         BAL   R14,TPUT                Write message on screen          00027000
+         B     RETURN8                 And branch                       00027100
+RETURN2  DS    0H                                                       00027200
+         MVC   MSG6+14(8),USERID       UserID in message                00027300
+         LA    R1,MSG6                 Msg: 'successfully deleted'      00027400
+         LA    R0,L'MSG6               Length                           00027500
+         BAL   R14,TPUT                Write message on screen          00027600
+         LA    R1,MSGA                 Msg: 'run RAKFUSER ...'          00027700
+         LA    R0,L'MSGA               Length                           00027800
+         BAL   R14,TPUT                Write message on screen          00027900
+RETURN8  DS    0H                                                       00028000
+         ICM   R8,15,ANSWER            Pointer to PDE's (the PDL)       00028100
+         BZ    RETURN9                 No: skip                         00028200
+         IKJRLSA (R8)                  Release PARSE storage            00028300
+RETURN9  LR    R3,R13                  Load working storage to free     00028400
+         L     R13,4(,R13)             Load caller's save area          00028500
+         FREEMAIN RU,LV=WORKL,A=(3)    Release working storage          00028600
+         LR    R15,R4                  Restore return code              00028700
+         RETURN (14,12),RC=(15)        Return                           00028800
+*                                                                       00028900
+         TITLE 'Invoke IKJDAIR, A(Parm block) in R1'                    00029000
+*---------------------------------------------------------------------* 00029100
+*        Routine:   CALLTS                                            * 00029200
+*        Function:  Invoke IKJDAIR to allocate or unallocate data sets* 00029300
+*                   Register 1 contains the address of the allocation * 00029400
+*                   or unallocation DAIR parameter blocks.            * 00029500
+*---------------------------------------------------------------------* 00029600
+CALLTS   DS    0H                                                       00029700
+         ST    R14,R14TS               Save register 14                 00029800
+         LR    R14,R1                  Save A(IKJDAIR parm block)       00029900
+         XC    ECB,ECB                 Clear ECB                        00030000
+         LA    R1,DAIRDAPL                                              00030100
+         L     R2,MYCPPL               Pickup our CPPL                  00030200
+         USING CPPL,R2                 Base CPPL                        00030300
+         USING DAPL,R1                 Base IKJDAPL                     00030400
+         MVC   DAPLUPT(4),CPPLUPT                                       00030500
+         MVC   DAPLECT(4),CPPLECT                                       00030600
+         XC    ECB,ECB                 Clear Event control block        00030700
+         LA    R0,ECB                  Address of our ECB               00030800
+         ST    R0,DAPLECB              Set A(ECB) in DAPL               00030900
+         MVC   DAPLPSCB(4),CPPLPSCB                                     00031000
+         ST    R14,DAPLDAPB            Set A(parm block) in DAPL        00031100
+         CALLTSSR EP=IKJDAIR,MF=(E,DAIRDAPL)                            00031200
+         L     R14,R14TS               Restore register 14              00031300
+         BR    R14                                                      00031400
+         DROP  R1,R2                   Unbase DAPL and CPPL             00031500
+         TITLE 'Write message on screen, r0=length, r1=address msg'     00031600
+TPUT     DS    0H                                                       00031700
+         ST    R14,R14TPUT             Save register 14                 00031800
+         TPUT  (1),(0),R                                                00031900
+         L     R14,R14TPUT             Restore register 14              00032000
+         BR    R14                     Return                           00032100
+         TITLE 'Free SYS.SECURE.CNTL and SYS1.SECURE.SHADOW'            00032200
+FREE     DS    0H                                                       00032300
+         ST    R14,R14FREE             Save register 14                 00032400
+         LA    R3,DAIR18               Point to unallocation parm block 00032500
+         XC    DAIR18,DAIR18           Clear unallocation parm block    00032600
+         USING DAPB18,R3               IKJDAP18                         00032700
+         MVI   DA18CD+1,X'18'          Entry code 0018 (unallocate)     00032800
+         MVI   DA18MNM,C' '            Provide no ...                   00032900
+         MVC   DA18MNM+1(7),DA18MNM               member name           00033000
+         MVC   DA18DDN,=CL8'RAKFUSER'  DDNAME to unallocate             00033100
+         LR    R1,R3                   Parameter CALLTS                 00033200
+         BAL   R14,CALLTS              IKJDAIR routine                  00033300
+         MVC   DA18DDN,=CL8'RAKFSHAD'  DDNAME to unallocate             00033400
+         LR    R1,R3                   Parameter CALLTS                 00033500
+         BAL   R14,CALLTS              IKJDAIR routine                  00033600
+         L     R14,R14FREE             Restore register 14              00033700
+         BR    R14                     Return                           00033800
+         DROP  R3                      Unbase DAPB18                    00033900
+         TITLE 'Close RAKFUSER and RAKFSHAD'                            00034000
+CLOSE    ST    R14,R14CLOSE            Save register 14                 00034100
+         MVI   CLOSED,X'80'            First and only DCB               00034200
+         CLOSE RAKFUSER,MF=(E,CLOSED)                                   00034300
+         MVI   CLOSED,X'80'            First and only DCB               00034400
+         CLOSE RAKFSHAD,MF=(E,CLOSED)                                   00034500
+         L     R14,R14CLOSE            Restore register 14              00034600
+         BR    R14                     Return                           00034700
+         TITLE 'DCB abend exit'                                         00034800
+DCBABEND DS    0H                                                       00034900
+         TM    3(R1),B'00001110'       Processing allowed?              00035000
+         BZR   R14                     No: continue with abend          00035100
+         TM    3(R1),4                 Ignore bit on?                   00035200
+         MVI   3(R1),0                 Prepare for NO                   00035300
+         BZR   R14                                                      00035400
+         MVC   DCBCOMP,0(R1)           Move completion code             00035500
+         NC    DCBCOMP,=X'FFF0'        Clear last nibble                00035600
+         CLC   DCBCOMP,=X'9130'        Do we have an RACF/ACF2 abend?   00035700
+         BNER  R14                     No: continue with abend          00035800
+         MVI   3(R1),4                 Yes: ignore abend                00035900
+         OI    SW,$913                 Indicate 913 abend               00036000
+         BR    R14                     Return to Access Method          00036100
+PCLSTART DS    0H                                                       00036200
+ADDPCL   IKJPARM DSECT=ADDPRS          PDE's                            00036300
+UIDPDE   IKJPOSIT JOBNAME,PROMPT='RAKF UserID',                        *00036400
+               HELP=('Enter a valid UserID')                            00036500
+         IKJENDP                                                        00036600
+PCL#L    EQU   *-PCLSTART                                               00036700
+         TITLE 'CONSTANTS'                                              00036800
+MDLSHAD  DCB   DSORG=PS,LRECL=48,DDNAME=RAKFSHAD,EODAD=SHADEOF,        *00036900
+               MACRF=(GM,PM)                                            00037000
+MDLSLEN  EQU   *-MDLSHAD                                                00037100
+MDLUSER  DCB   DSORG=PS,LRECL=80,DDNAME=RAKFUSER,EODAD=USEREOF,        *00037200
+               MACRF=(GM,PM)                                            00037300
+MDLULEN  EQU   *-MDLUSER                                                00037400
+*                                                                       00037500
+USRDSNL  DC    AL2(L'USRDSN)                                            00037600
+USRDSN   DC    C'SYS1.SECURE.CNTL'     RAKF control data set            00037701
+SHDDSNL  DC    AL2(L'SHDDSN)                                            00037800
+SHDDSN   DC    C'SYS1.SECURE.SHADOW'   RAKF data set with encrypted psw 00037901
+*                                                                       00038000
+MSG1     DC    C'SYS1.SECURE.USER could not be allocated'               00038100
+MSG2     DC    C'SYS1.SECURE.SHADOW could not be allocated'             00038200
+MSG3X    DC    C'DELUSER: xxxxxxxx access denied'  +9                   00038300
+MSG4     DC    C'DELUSER: Nothing deleted'                              00038400
+MSG5     DC    C'DELUSER: Parse error'                                  00038500
+MSG6X    DC    C'DELUSER: User xxxxxxxx successfully deleted' +14       00038600
+MSG7     DC    C'DELUSER: User table full, too many users'              00038700
+MSGA     DC    C'DELUSER: Run RAKFUSER to activate the changes'         00038800
+         LTORG ,                                                        00038900
+         DROP                                                           00039000
+UIDRET   DSECT                         PDE of UserID                    00039100
+UIDPTR   DS    F                       Pointer to UserID                00039200
+UIDL     DS    H                       Length of UserID                 00039300
+UIDFLG   DS    C                                                        00039400
+$UPRES   EQU   128                     Group(s) are present             00039500
+         DS    C                       Reserved                         00039600
+*                                                                       00039700
+WORKAREA DSECT                         Working storage                  00039800
+         DS    18F                     Our save area                    00039900
+MYCPPL   DS    F                                                        00040000
+DAIRDAPL DS    5F                      DAIR parameter list              00040100
+ECB      DS    F                       For IKJDAIR                      00040200
+R14CLOSE DS    F                       Register 14 CLOSE                00040300
+R14FREE  DS    F                       Register 14 FREE                 00040400
+R14TPUT  DS    F                       Register 14 TPUT                 00040500
+R14TS    DS    F                       Register 14 CALLTS               00040600
+ADRUSER  DS    F                       Address of storage table         00040700
+EXLST    DS    F                       DCB abend exit                   00040800
+OPEND    DS    F                       OPEN MF=L                        00040900
+CLOSED   DS    F                       CLOSE MF=L                       00041000
+ANSWER   DS    F                       Parse answer area                00041100
+*                                                                       00041200
+USERID   DS    CL8                     To receive UserID                00041300
+*                                                                       00041400
+DCBCOMP  DS    H                       Completion code in DCBABEND      00041500
+*                                                                       00041600
+RAKFSHAD DS    CL(MDLSLEN)                                              00041700
+RAKFUSER DS    CL(MDLULEN)                                              00041800
+*                                                                       00041900
+*                                                                       00042000
+PPL#LA   DS    F                       \___ Length + address PPL ____/  00042100
+PPL#PTR  DS    F                       /                             \  00042200
+*                                                                       00042300
+DAIR08   DS    CL84                    Allocation parm block            00042400
+DAIR18   DS    CL40                    Unallocation parm block          00042500
+*                                                                       00042600
+USERREC  DS    0CL80                   User record                      00042700
+USERUID  DS    CL8                     Contains UserID                  00042800
+USERDFT  DS    C                       * for default group              00042900
+USERGRP  DS    CL8                     Group                            00043000
+         DS    C                                                        00043100
+USERPWD  DS    CL8                     Password is blanked out          00043200
+         DS    C                                                        00043300
+USEROPR  DS    C                       Operations / Nooperations        00043400
+         DS    C                                                        00043500
+USERSPE  DS    C                       Special / Nospecial              00043600
+         DS    CL50                    Filler                           00043700
+*                                                                       00043800
+SHADOW   DS    0CL48                   Shadow record                    00043900
+SHDUID   DS    CL8                     UserID (key)                     00044000
+SHDSALT  DS    CL8                     SALT                             00044100
+SHDHASH  DS    CL32                    HASH                             00044200
+*                                                                       00044300
+MSG3     DS    CL(L'MSG3X)                                              00044400
+MSG6     DS    CL(L'MSG6X)                                              00044500
+SW       DS    X                       Flags                            00044600
+$913     EQU   128                     913 abend occurred               00044700
+$DEL     EQU   64                      User is deleted                  00044800
+*                                                                       00044900
+WORKL    EQU   *-WORKAREA              Length of working storage        00045000
+*                                                                       00045100
+         CVT   DSECT=YES,LIST=NO                                        00045200
+         IKJCPPL                                                        00045300
+         IKJUPT                                                         00045400
+         IKJPPL                        Parse parameter list             00045500
+PPL#L    EQU   *-PPL                                                    00045600
+         IKJDAPL                                                        00045700
+         IKJDAP08                      IKJDAIR allocation parm block    00045800
+         IKJDAP18                      IKJDAIR unallocation parm block  00045900
+         PRINT NOGEN                                                    00046000
+         DCBD  DSORG=PS,DEVD=DA                                         00046100
+*                                                                       00046200
+R0       EQU   0                                                        00046300
+R1       EQU   1                                                        00046400
+R2       EQU   2                                                        00046500
+R3       EQU   3                                                        00046600
+R4       EQU   4                                                        00046700
+R5       EQU   5                                                        00046800
+R6       EQU   6                                                        00046900
+R7       EQU   7                                                        00047000
+R8       EQU   8                       Address of IKJPARS PDL           00047100
+R9       EQU   9                                                        00047200
+R10      EQU   10                                                       00047300
+R11      EQU   11                                                       00047400
+R12      EQU   12                      Base register                    00047500
+R13      EQU   13                      Address of working storage       00047600
+R14      EQU   14                                                       00047700
+R15      EQU   15                                                       00047800
+         END                                                            00047900

--- a/SRCLIB/deluser.hlasm
+++ b/SRCLIB/deluser.hlasm
@@ -189,9 +189,11 @@ DELU009  DS    0H                                                       00017700
          BAL   R14,CLOSE               Close RAKFUSER and RAKFSHAD      00018900
          BAL   R14,FREE                Free the data sets               00019000
          B     RC08                    Return code 8                    00019100
-DELU010  OI    SW,$DEL                 Mark User deleted                00019200
+DELU010  OI    SW,$DELU                Mark User deleted from USERS     00019200
          B     DELU009                 Read next record                 00019300
 USEREOF  DS    0H                      EOF RACFUSER                     00019400
+         TM    SW,$DELU                Is a user deleted from USERS?    00019401
+         BZ    DELU013                 No: no sense to write table back 00019402
          L     R6,ADRUSER              Point to start of table          00019500
          MVI   CLOSED,X'80'            First and only DCB               00019600
          CLOSE RAKFUSER,MF=(E,CLOSED)                                   00019700
@@ -224,9 +226,11 @@ DELU015  DS    0H                                                       00021900
          LA    R5,1(,R5)               Count record in table            00022400
          LA    R6,48(,R6)              Next entry in table              00022500
          B     DELU015                 Read next record                 00022600
-DELU016  OI    SW,$DEL                 Mark User deleted                00022700
+DELU016  OI    SW,$DELS                Mark User deleted from SHADOW    00022700
          B     DELU015                 Read next record                 00022800
 SHADEOF  DS    0H                      EOF RACFSHAD                     00022900
+         TM    SW,$DELS                Is a user deleted from SAHADOW?  00022901
+         BZ    DELU021                 No: no sense to write table back 00022902
          L     R6,ADRUSER              Start of user table              00023000
          MVI   CLOSED,X'80'            First and only DCB               00023100
          CLOSE RAKFSHAD,MF=(E,CLOSED)                                   00023200
@@ -263,7 +267,7 @@ RETURN   DS    0H                                                       00026000
          FREEMAIN RU,LV=(2),A=(3)      Free the PPL                     00026300
          L     R2,ADRUSER              Address of user table            00026400
          FREEMAIN RU,LV=104000,A=(2)                                    00026500
-         TM    SW,$DEL                 Anything deleted?                00026600
+         TM    SW,$DELU+$DELS          Anything deleted?                00026600
          BNZ   RETURN2                 Yes: carry on                    00026700
          LA    R1,MSG4                 Msg: 'nothing deleted'           00026800
          LA    R0,L'MSG4               Length                           00026900
@@ -445,7 +449,8 @@ MSG3     DS    CL(L'MSG3X)                                              00044400
 MSG6     DS    CL(L'MSG6X)                                              00044500
 SW       DS    X                       Flags                            00044600
 $913     EQU   128                     913 abend occurred               00044700
-$DEL     EQU   64                      User is deleted                  00044800
+$DELU    EQU   64                      User is deleted from USERS       00044800
+$DELS    EQU   32                      User is deleted from SHADOW      00044801                 
 *                                                                       00044900
 WORKL    EQU   *-WORKAREA              Length of working storage        00045000
 *                                                                       00045100


### PR DESCRIPTION
This file implements the DELUSER module, which is responsible for deleting RAKF users from control data sets. It includes functions for parsing commands, managing user records, and handling data set allocations.