### PR TITLE
New HELP member of ALTUSER

### DIFF
--- a/HELP/ALTUSER
+++ b/HELP/ALTUSER
@@ -1,93 +1,94 @@
-)FUNCTION
-  THE ALTUSER COMMAND CHANGES AN EXISTING RAKF USER.  IT CAN SET A NEW
-  PASSWORD, MOVE THE DEFAULT GROUP FLAG, AND TURN THE OPERATIONS AND
-  SPECIAL ATTRIBUTES ON OR OFF.  A NEW PASSWORD IS RE-HASHED WITH A
-  FRESH SALT AND REPLACES THE RECORD IN SYS1.SECURE.SHADOW; NO CLEAR
-  TEXT PASSWORD IS EVER STORED.
-
-  AT LEAST ONE CHANGE MUST BE REQUESTED.  IF NONE IS, THE COMMAND ENDS
-  WITH RETURN CODE 8 AND NOTHING IS WRITTEN.
-
-  ALTUSER UPDATES THE CONTROL DATA SETS ON DISK ONLY.  RELOAD THE IN
-  CORE TABLES AFTERWARDS WITH 'S RAKFUSER' FROM THE CONSOLE, OR BY
-  RUNNING THE RAKFUSER PROCEDURE IN BATCH, OR THE CHANGE DOES NOT TAKE
-  EFFECT YET.
-
-  YOU MUST BE CONNECTED TO THE RAKFADM GROUP.  ALTUSER IS AN ORDINARY
-  PROBLEM STATE PROGRAM - IT IS THE PROTECTION ON THE CONTROL DATA SETS
-  THAT ENFORCES THIS, NOT APF AUTHORISATION.
-
-  ALTUSER CANNOT CONNECT A USER TO A NEW GROUP OR REMOVE ONE.  CONNECT,
-  REMOVE AND DELUSER ARE NOT YET IMPLEMENTED.
-)SYNTAX
-  ALTUSER USERID [PASSWORD(PW)] [DFLTGRP(GROUP)]
-          [OPERATIONS|NOOPERATIONS] [SPECIAL|NOSPECIAL]
-
-  REQUIRED - USERID, PLUS AT LEAST ONE OF THE OTHER OPERANDS
-  DEFAULT  - ANY ATTRIBUTE NOT NAMED IS LEFT UNCHANGED
-
-  ALL INPUT IS FOLDED TO UPPER CASE.
-
-  EXAMPLES FROM A TSO SESSION:
-
-    ALTUSER SMITH PASSWORD(NEWPW99)
-
-    ALTUSER JONES DFLTGRP(RAKFADM) SPECIAL NOOPERATIONS
-
-  IN BATCH, INVOKE IT WITH CALL SO THE LOAD MODULE IS FOUND, AND
-  SUPPLY ALL OF THESE DD STATEMENTS:
-
-    //ALTUSER  EXEC PGM=IKJEFT01,REGION=4096K
-    //SYSPRINT DD  SYSOUT=*
-    //SYSTERM  DD  SYSOUT=*
-    //SYSIN    DD  DUMMY
-    //SYSTSPRT DD  SYSOUT=*
-    //USERS    DD  DSN=SYS1.SECURE.CNTL(USERS),DISP=SHR
-    //SHADOW   DD  DSN=SYS1.SECURE.SHADOW,DISP=SHR
-    //SYSTSIN  DD  *
-      CALL 'SYS2.CMDLIB(ALTUSER)' +
-    'SMITH PASSWORD(NEWPW99)'
-
-  KEEP THE COMMAND WITHIN COLUMN 72 AND CONTINUE WITH A PLUS SIGN.
-
-  EVERY ONE OF THOSE DD STATEMENTS MATTERS:
-
-  SYSPRINT, SYSTERM AND SYSIN ARE OPENED BEFORE THE COMMAND ITSELF
-  STARTS.  IF ANY CANNOT BE OPENED THE PROGRAM ENDS IMMEDIATELY, SO
-  THE STEP FAILS WITH RC=12 AND AN EMPTY SYSTSPRT - NO MESSAGE AT ALL
-  EXPLAINING WHY.
-
-  USERS AND SHADOW MUST BE PRE-ALLOCATED.  SYS1.SECURE.* IS PROTECTED
-  WITH UACC(NONE), AND ALLOCATING IT DYNAMICALLY DOES NOT SUCCEED -
-  THE COMMAND REPORTS "CANNOT OPEN USERS."  UNPROTECTED DATA SETS ARE
-  FOUND WITHOUT HELP, SO NO DD IS NEEDED FOR SYS1.PROCLIB.
-
-  REGION 4096K: A 512K REGION IS TOO SMALL FOR THE COMMAND TO START.
-
-  RETURN CODES:
-
-     0 - THE USER WAS CHANGED.
-     8 - USAGE OR VALIDATION ERROR.  A BAD OPERAND, NO CHANGE WAS
-         REQUESTED, OR DFLTGRP NAMED A GROUP THE USER IS NOT CONNECTED
-         TO.
-    12 - THE CONTROL DATA SETS COULD NOT BE READ OR WRITTEN.  CHECK
-         THAT YOU ARE CONNECTED TO RAKFADM.
-)OPERANDS
-)USERID - THE USER TO CHANGE.  1 TO 8 CHARACTERS.  REQUIRED, AND MUST
-  BE THE FIRST OPERAND.
-)PASSWORD - PASSWORD(PW) REPLACES THE PASSWORD.  OPTIONAL.  1 TO 8
-  CHARACTERS.  A FRESH SALT IS GENERATED AND THE SHADOW RECORD IS
-  REWRITTEN, SO THE OLD PASSWORD STOPS WORKING AS SOON AS THE IN CORE
-  TABLES ARE RELOADED.
-)DFLTGRP - DFLTGRP(GROUP) MOVES THE '*' DEFAULT FLAG TO THE NAMED
-  GROUP.  OPTIONAL.  THE USER MUST ALREADY BE CONNECTED TO THAT GROUP;
-  IF NOT, THE COMMAND ENDS WITH RETURN CODE 8 AND NOTHING IS WRITTEN.
-  USE ADDUSER TO CREATE A USER WITH THE GROUPS YOU NEED.
-)OPERATIONS - TURNS THE OPERATIONS ATTRIBUTE ON (Y) FOR EVERY LINE OF
-  THE USER.  OPTIONAL.
-)NOOPERATIONS - TURNS THE OPERATIONS ATTRIBUTE OFF (N) FOR EVERY LINE
-  OF THE USER.  OPTIONAL.
-)SPECIAL - TURNS THE SPECIAL ATTRIBUTE ON (Y) FOR EVERY LINE OF THE
-  USER.  OPTIONAL.
-)NOSPECIAL - TURNS THE SPECIAL ATTRIBUTE OFF (N) FOR EVERY LINE OF THE
-  USER.  OPTIONAL.
+)F FUNCTION -                                                                   
+  The ALTUSER command changes an existing RAKF user.  It can set a new          
+  password, move the default group flag, and turn the OPERATIONS and            
+  SPECIAL attributes on or off.  A new password is re-hashed with a             
+  fresh salt and replaces the record in SYS1.SECURE.SHADOW; no clear            
+  text password is ever stored.                                                 
+                                                                                
+  At least one change must be requested.  If none is, the command ends          
+  and the user receives the message "ALTUSER: userid is not altered".           
+                                                                                
+  ALTUSER updates the control data sets on disk only.  Reload the in            
+  core tables afterwards with 'S RAKFUSER' from the console, or by              
+  running the RAKFUSER procedure in batch, or the change does not take          
+  effect yet.                                                                   
+                                                                                
+  You must be connected to the RAKFADM group.  ALTUSER is an ordinary           
+  problem state program - it is the protection on the control data sets         
+  that enforces this, not APF authorization.                                    
+                                                                                
+  ALTUSER cannot connect a user to a new group or remove one, but the           
+  user can be deleted with DELUSER and recreated with the right                 
+  groups with ADDUSER.                                                          
+)X SYNTAX -                                                                     
+  ALTUSER USERID | PASSWORD(PW) | DFLTGRP(GROUP)                                
+          | OPERATIONS   | SPECIAL                                              
+          | NOOPERATIONS | NOSPECIAL                                            
+                                                                                
+  Required - Userid, plus at least one of the other operands                    
+  Default  - Any attribute not named is left unchanged                          
+                                                                                
+  All input is folded to upper case.                                            
+                                                                                
+  Examples from a TSO session:                                                  
+                                                                                
+    ALTUSER SMITH PASSWORD(NEWPW99)                                             
+                                                                                
+    ALTUSER JONES DFLTGRP(RAKFADM) SPECIAL NOOPERATIONS                         
+                                                                                
+  The operands can be shortened to the shortest unique abbreviation.            
+  So, ALTUSER JONES D(RAKFADM) S NOOP is also valid.                            
+                                                                                
+  In batch, invoke it from the TMP so the load module is found, and             
+  supply all of these DD statements:                                            
+                                                                                
+    //ALTUSER  EXEC PGM=IKJEFT01,REGION=4096K                                   
+    //SYSPRINT DD  SYSOUT=*                                                     
+    //SYSTERM  DD  SYSOUT=*                                                     
+    //SYSIN    DD  DUMMY                                                        
+    //SYSTSPRT DD  SYSOUT=*                                                     
+    //SYSTSIN  DD  *                                                            
+     ALTUSER 'SMITH PASSWORD(NEWPW99)'                                          
+                                                                                
+  Keep the command within column 72 and continue with a plus sign.              
+                                                                                
+  Every one of those DD statements matters:                                     
+                                                                                
+  SYSPRINT, SYSTERM and SYSIN are opened before the command itself              
+  starts.  If any cannot be opened the program ends immediately, so             
+  The step fails with RC=8 - The user will be notified with                     
+  a suitable message.                                                           
+                                                                                
+  USERS and SHADOW are dynamically allocated. SYS1.SECURE.* is                  
+  protected with UACC(NONE), so the user needs the RAKFADM group.               
+  The command reports "RAKFUSER access denied" or                               
+  "RAKFSHAD access denied" if trying to run with a group other                  
+  than RAKFADM.                                                                 
+                                                                                
+  RETURN CODES:                                                                 
+                                                                                
+     0 - The user was altered.                                                  
+     8 - An error occurs. A suitable message will be given to                   
+         the user.                                                              
+)O OPERANDS -                                                                   
+))USERID - The user to change.  1 to 8 characters.  Required, and must          
+  be the first operand.                                                         
+))PASSWORD - PASSWORD(pw) replaces the password.  Optional.  1 to 8             
+  characters.  A fresh salt is generated and the SHADOW record is               
+  rewritten, so the old password stops working as soon as the in core           
+  tables are reloaded.                                                          
+  An alias of PASSWORD is PWD.                                                  
+))DFLTGRP - DFLTGRP(group) moves the '*' default flag to the named              
+  group. Optional. The user must already be connected to that group;            
+  If not, the command ends with a suitable message.                             
+  Use ADDUSER to create a user with the groups you need.                        
+  An alias of DFLTGRP is DGRP.                                                  
+))OPERATIONS - Turns the OPERATIONS attribuat on (Y) for every line of          
+  the user.  Optional.                                                          
+))NOOPERATIONS - Turns the OPERATIONS attribute off (N) for every line          
+  of the user.  Optional.                                                       
+))SPECIAL - Turns the SPECIAL attribute on (Y) for every line of the            
+  user.  optional.                                                              
+))NOSPECIAL - Turns the SPECIAL attribute off (N) for every line of the         
+  user.  optional.                                                              
+                                                                                


### PR DESCRIPTION
The old member was syntactically incorrect.
And I have changed it according the new ALTUSER command.